### PR TITLE
Do not allow directory creation outside docroot.

### DIFF
--- a/index.php
+++ b/index.php
@@ -70,6 +70,11 @@ if($_GET['do'] == 'list') {
 	rmrf($file);
 	exit;
 } elseif ($_POST['do'] == 'mkdir') {
+	// don't allow actions outside root. we also filter out slashes to catch args like './../outside'
+	$dir = $_POST['name'];
+	$dir = str_replace('/', '', $dir);
+	if(substr($dir, 0, 2) === '..')
+	    exit;
 	chdir($file);
 	@mkdir($_POST['name']);
 	exit;


### PR DESCRIPTION
Before, it was possible to enter stuff like '../bla' in the dir creation field and have that created outside the docroot.