### PR TITLE
Use the builtins hash_equals function to prevent timing attacks

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,9 +15,8 @@ $allow_delete = true;
 $PASSWORD = 'sfm'; 
 session_start();
 if(!$_SESSION['_sfm_allowed']) {
-	// sha1, and random bytes to thwart timing attacks.  Not meant as secure hashing.
-	$t = bin2hex(openssl_random_pseudo_bytes(10));	
-	if($_POST['p'] && sha1($t.$_POST['p']) === sha1($t.$PASSWORD)) {
+	// mitigate timing attacks
+	if($_POST['p'] && hash_equals($PASSWORD, $_POST['p'])) {
 		$_SESSION['_sfm_allowed'] = true;
 		header('Location: ?');
 	}

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ $PASSWORD = 'sfm';
 session_start();
 if(!$_SESSION['_sfm_allowed']) {
 	// mitigate timing attacks
-	if($_POST['p'] && hash_equals($PASSWORD, $_POST['p'])) {
+	if(isset($_POST['p']) && hash_equals($PASSWORD, $_POST['p'])) {
 		$_SESSION['_sfm_allowed'] = true;
 		header('Location: ?');
 	}


### PR DESCRIPTION
According to https://secure.php.net/manual/de/function.hash-equals.php, the `hash_equals` "function should be used to mitigate timing attack".

It is built in PHP since version 5.6.0 (I didn't see anything about what version you intend to support on the Readme.