### PR TITLE
PHP notices

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,21 +29,21 @@ if(!$_SESSION['_sfm_allowed']) {
 // must be in UTF-8 or `basename` doesn't work
 setlocale(LC_ALL,'en_US.UTF-8');
 
-$tmp = realpath($_REQUEST['file']);
+$tmp = realpath(isset($_REQUEST['file']) ? $_REQUEST['file'] : __DIR__);
 if($tmp === false)
 	err(404,'File or Directory Not Found');
 if(substr($tmp, 0,strlen(__DIR__)) !== __DIR__)
 	err(403,"Forbidden");
 
-if(!$_COOKIE['_sfm_xsrf'])
+if(empty($_COOKIE['_sfm_xsrf']))
 	setcookie('_sfm_xsrf',bin2hex(openssl_random_pseudo_bytes(16)));
 if($_POST) {
 	if($_COOKIE['_sfm_xsrf'] !== $_POST['xsrf'] || !$_POST['xsrf'])
 		err(403,"XSRF Failure");
 }
 
-$file = $_REQUEST['file'] ?: '.';
-if($_GET['do'] == 'list') {
+$file = !empty($_REQUEST['file']) ? $_REQUEST['file'] : '.';
+if(isset($_GET['do']) && $_GET['do'] == 'list') {
 	if (is_dir($file)) {
 		$directory = $file;
 		$result = array();
@@ -72,12 +72,12 @@ if($_GET['do'] == 'list') {
 	}
 	echo json_encode(array('success' => true, 'is_writable' => is_writable($file), 'results' =>$result));
 	exit;
-} elseif ($_POST['do'] == 'delete') {
+} elseif (isset($_POST['do']) && $_POST['do'] == 'delete') {
 	if($allow_delete) {
 		rmrf($file);
 	}
 	exit;
-} elseif ($_POST['do'] == 'mkdir') {
+} elseif (isset($_POST['do']) && $_POST['do'] == 'mkdir') {
 	// don't allow actions outside root. we also filter out slashes to catch args like './../outside'
 	$dir = $_POST['name'];
 	$dir = str_replace('/', '', $dir);
@@ -86,19 +86,19 @@ if($_GET['do'] == 'list') {
 	chdir($file);
 	@mkdir($_POST['name']);
 	exit;
-} elseif ($_POST['do'] == 'upload') {
+} elseif (isset($_POST['do']) && $_POST['do'] == 'upload') {
 	var_dump($_POST);
 	var_dump($_FILES);
 	var_dump($_FILES['file_data']['tmp_name']);
 	var_dump(move_uploaded_file($_FILES['file_data']['tmp_name'], $file.'/'.$_FILES['file_data']['name']));
 	exit;
-} elseif ($_GET['do'] == 'download') {
+} elseif (isset($_GET['do']) && $_GET['do'] == 'download') {
 	$filename = basename($file);
 	header('Content-Type: ' . mime_content_type($file));
 	header('Content-Length: '. filesize($file));
 	header(sprintf('Content-Disposition: attachment; filename=%s',
 		strpos('MSIE',$_SERVER['HTTP_REFERER']) ? rawurlencode($filename) : "\"$filename\"" ));
-	ob_flush();
+	flush();
 	readfile($file);
 	exit;
 }


### PR DESCRIPTION
If you have enable display PHP notices, then you will see something like this:
![notices](https://cloud.githubusercontent.com/assets/1105278/21651136/c9d9ba8a-d2a7-11e6-8ea1-05834602b65e.png)

Additionally, you can't download file. Downloaded file will have something like this:
````
<br />
<font size='1'><table class='xdebug-error xe-notice' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Notice: ob_flush(): failed to flush buffer. No buffer to flush in /home/marcin/public_html/simple-file-manager/index.php on line <i>101</i></th></tr>
<tr><th align='left' bgcolor='#e9b96e' colspan='5'>Call Stack</th></tr>
<tr><th align='center' bgcolor='#eeeeec'>#</th><th align='left' bgcolor='#eeeeec'>Time</th><th align='left' bgcolor='#eeeeec'>Memory</th><th align='left' bgcolor='#eeeeec'>Function</th><th align='left' bgcolor='#eeeeec'>Location</th></tr>
<tr><td bgcolor='#eeeeec' align='center'>1</td><td bgcolor='#eeeeec' align='center'>0.0014</td><td bgcolor='#eeeeec' align='right'>280488</td><td bgcolor='#eeeeec'>{main}(  )</td><td title='/home/marcin/public_html/simple-file-manager/index.php' bgcolor='#eeeeec'>.../index.php<b>:</b>0</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>2</td><td bgcolor='#eeeeec
````
