### PR TITLE
Fix if for new folder form

### DIFF
--- a/index.php
+++ b/index.php
@@ -431,7 +431,7 @@ $(function(){
 </script>
 </head><body>
 <div id="top">
-   <?php if($allow_upload == true): ?>
+   <?php if($allow_create_folder == true): ?>
 	<form action="?" method="post" id="mkdir" />
 		<label for=dirname>Create New Folder</label><input id=dirname type=text name=name value="" />
 		<input type="submit" value="create" />


### PR DESCRIPTION
The `Create New Folder` form appears even if `$allow_create_folder = false;` since it checks the wrong variable (`$allow_upload`). This PR fixes this issue by checking the right `$allow_create_folder` variable.