### PR TITLE
Fix breadcrumbs navigation, again

### DIFF
--- a/index.php
+++ b/index.php
@@ -433,7 +433,7 @@ $(function(){
 	function renderBreadcrumbs(path) {
 		var base = "",
 			$html = $('<div/>').append( $('<a href=#>Home</a></div>') );
-		$.each(path.split('%2F'),function(k,v){
+		$.each(path.split(/\/|%2F/i),function(k,v){
 			if(v) {
 				var v_as_text = decodeURIComponent(v);
 				$html.append( $('<span/>').text(' ▸ ') )


### PR DESCRIPTION
After pull requests #66 and #93 were merged, old unescaped URIs (from
browser history or external links) were no longer properly decomposed.

Use a regex instead of a string to match unescaped as well as escaped
directory separators in URI.